### PR TITLE
Add delay timer for animation start and improve disposal handling

### DIFF
--- a/lib/auto_scroll_text.dart
+++ b/lib/auto_scroll_text.dart
@@ -253,6 +253,7 @@ class _AutoScrollTextState extends State<AutoScrollText> {
   String? _endlessText;
   double? _originalTextWidth;
   Timer? _timer;
+  Timer? _delayTimer; // Timer to handle delay before animation
   bool _running = false;
   int _counter = 0;
   @override
@@ -276,6 +277,7 @@ class _AutoScrollTextState extends State<AutoScrollText> {
 
   @override
   void dispose() {
+    _delayTimer?.cancel();
     _timer?.cancel();
     super.dispose();
   }
@@ -318,18 +320,19 @@ class _AutoScrollTextState extends State<AutoScrollText> {
   }
 
   Future<void> _initScroll(_) async {
-    await _delayBeforeStartAnimation();
-    _timer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
-      if (!_available) {
-        timer.cancel();
-        return;
-      }
-      final int? maxReps = widget.numberOfReps;
-      if (maxReps != null && _counter >= maxReps) {
-        timer.cancel();
-        return;
-      }
-      if (!_running) _runAnimation();
+    _delayTimer = Timer(widget.delayBefore ?? Duration.zero, () {
+      _timer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
+        if (!_available) {
+          timer.cancel();
+          return;
+        }
+        final int? maxReps = widget.numberOfReps;
+        if (maxReps != null && _counter >= maxReps) {
+          timer.cancel();
+          return;
+        }
+        if (!_running) _runAnimation();
+      });
     });
   }
 
@@ -406,12 +409,6 @@ class _AutoScrollTextState extends State<AutoScrollText> {
     if (widget.pauseBetween != null) {
       await Future<dynamic>.delayed(widget.pauseBetween!);
     }
-  }
-
-  Future<void> _delayBeforeStartAnimation() async {
-    final Duration? delayBefore = widget.delayBefore;
-    if (delayBefore == null) return;
-    await Future<dynamic>.delayed(delayBefore);
   }
 
   Duration _getDuration(double extent) {

--- a/test/auto_scroll_text_test.dart
+++ b/test/auto_scroll_text_test.dart
@@ -1,5 +1,30 @@
+import 'package:auto_scroll_text/auto_scroll_text.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('adds one to input values', () {});
+
+  testWidgets(
+    'AutoScrollText disposes correctly before delayBefore duration in bouncing mode',
+    (tester) async {
+      // GIVEN
+      await tester.pumpWidget(const AutoScrollText(
+        'Hello World',
+        delayBefore: Duration(seconds: 6),
+        mode: AutoScrollTextMode.bouncing,
+      ));
+
+      // Verify the widget is rendered
+      expect(find.text('Hello World'), findsOneWidget);
+
+      // The widget is expected to dispose before the delayBefore duration (6 seconds)
+      // without throwing any exceptions or errors.
+
+      // WHEN
+
+      // THEN
+      // Disposed before delayBefore fire, in this case 6 seconds
+      // should be ok
+    },
+  );
 }


### PR DESCRIPTION
**Fix: Resolve Pending Timer Issue During Widget Disposal**

**Problem**

During widget tests, the following error occurred when using the `AutoScrollText` widget with the `delayBefore` parameter:
`A Timer is still pending even after the widget tree was disposed.`

This issue arises because the widget is disposed before the `_delayBeforeStartAnimation` method completes its operation, leaving a pending timer.

**Solution**
	•	Replaced the `_delayBeforeStartAnimation` method with a direct call to start the timer (`_delayTimer`).
	•	The `_initScroll` method was updated to set up a new Timer for the `delayBefore` duration. Once the delay is over, the periodic timer is started for the scroll animation.
	•	Ensured that the timers are properly managed and canceled when the widget is disposed to prevent any lingering timers that may cause issues during widget tests.

**Changes**
	•	The new Timer is created with the `delayBefore` parameter directly inside `_initScroll`, instead of using a separate `_delayBeforeStartAnimation` method.
	•	Ensured that timers are disposed of correctly to prevent them from running after the widget is disposed.
	•	Added widget tests to validate the behavior, especially around the `delayBefore` parameter and its interaction with widget disposal in the context of Bouncing mode.

This update resolves the issue of pending timers during widget disposal, especially in automated tests.